### PR TITLE
Pester spec to verify that Exec executes script block in the specified working directory

### DIFF
--- a/specs/exec_executes_in_specified_location_should_pass.ps1
+++ b/specs/exec_executes_in_specified_location_should_pass.ps1
@@ -1,0 +1,22 @@
+Task default -depends Test
+
+Task Test {
+    [string[]]$global:locations = @()
+    [string[]]$expected = "env:\,variable:\,variable:\,variable:\,env:\"
+    [scriptblock]$cmd = {
+        $global:locations += Get-Location
+        throw "forced error"
+    }
+    Set-Location "env:"
+
+    $global:locations += Get-Location
+    try {
+        Exec -cmd $cmd -maxRetries 2 -workingDirectory "variable:"
+    }
+    catch {}
+    $global:locations += Get-Location
+
+     [string]$actual = $global:locations -join ","
+     $actual = $actual.ToLower()
+     Assert ($actual -eq $expected) "Expected: '$expected' Actual: '$actual'"
+}

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -65,14 +65,15 @@ function Exec {
         [string]$workingDirectory = $null
     )
 
-    if ($workingDirectory) {
-        Push-Location -Path $workingDirectory
-    }
-
     $tryCount = 1
 
     do {
         try {
+
+            if ($workingDirectory) {
+                Push-Location -Path $workingDirectory
+            }
+
             $global:lastexitcode = 0
             & $cmd
             if ($global:lastexitcode -ne 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Created a Pester spec which ensures the Exec function executes the provided script block in the specified working directory (including retries), and returns to the original location afterwards.

## Related Issue
#287

## Motivation and Context
Will ensure that your fix isn't regressed by future changes to the function.

## How Has This Been Tested?
I've tested the test against your code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
