### PR TITLE
Altering Pester spec for Execs working directory to be cross-platform

### DIFF
--- a/specs/exec_executes_in_specified_location_should_pass.ps1
+++ b/specs/exec_executes_in_specified_location_should_pass.ps1
@@ -1,17 +1,18 @@
 Task default -depends Test
 
 Task Test {
+    [string]$currentPath = Get-Location
+    [string]$parentPath = Split-Path $currentPath -Parent
     [string[]]$global:locations = @()
-    [string[]]$expected = "env:\,variable:\,variable:\,variable:\,env:\"
+    [string[]]$expected = "$currentPath,$parentPath,$parentPath,$parentPath,$currentPath"
     [scriptblock]$cmd = {
         $global:locations += Get-Location
         throw "forced error"
     }
-    Set-Location "env:"
 
     $global:locations += Get-Location
     try {
-        Exec -cmd $cmd -maxRetries 2 -workingDirectory "variable:"
+        Exec -cmd $cmd -maxRetries 2 -workingDirectory $parentPath
     }
     catch {}
     $global:locations += Get-Location


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously the test didn't account for Linux / Mac platforms, where the paths are represented differently. 

## Related Issue
#287

## Motivation and Context
Ensure Exec is covered with a Pester test to avoid future regression.

## How Has This Been Tested?
Tested on Windows and on Ubuntu. I don't have access to a Mac machine though.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
